### PR TITLE
Ignore hash and version during Bicep validation in build pipelines

### DIFF
--- a/pipelines/templates/stages/build.yml
+++ b/pipelines/templates/stages/build.yml
@@ -14,10 +14,15 @@ stages:
           - bash: az bicep build -f deploy/azuredeploy.bicep --outdir /tmp
             displayName: Compile Bicep
           - bash: |
-              cmp --silent /tmp/azuredeploy.json deploy/azuredeploy.json
+              diff <(tail -n +10 /tmp/azuredeploy.json) <(tail -n +10 deploy/azuredeploy.json)
               if [ $? -ne  0 ]; then
+                echo ''
                 echo '🚨 Compiled ARM json does not match'
-                echo '⚠️ Compile the bicep into ARM and commit to pass'
+                echo '⚠️ This error can be caused by a new release of Bicep'
+                echo '⚠️ To fix this issue:'
+                echo '⚠️ Update Bicep (az bicep upgrade)'
+                echo '⚠️ Rebuild the arm template (az bicep build -f azuredeploy.bicep)'
+                echo '⚠️ Commit the changes'
                 exit 1
               fi
             displayName: Verify built bicep matches ARM in repo

--- a/pipelines/templates/stages/build.yml
+++ b/pipelines/templates/stages/build.yml
@@ -14,14 +14,14 @@ stages:
           - bash: az bicep build -f deploy/azuredeploy.bicep --outdir /tmp
             displayName: Compile Bicep
           - bash: |
-              diff <(tail -n +10 /tmp/azuredeploy.json) <(tail -n +10 deploy/azuredeploy.json)
+              diff <(tail -n +9 /tmp/azuredeploy.json) <(tail -n +9 deploy/azuredeploy.json)
               if [ $? -ne  0 ]; then
                 echo ''
                 echo '🚨 Compiled ARM json does not match'
                 echo '⚠️ This error can be caused by a new release of Bicep'
                 echo '⚠️ To fix this issue:'
                 echo '⚠️ Update Bicep (az bicep upgrade)'
-                echo '⚠️ Rebuild the arm template (az bicep build -f azuredeploy.bicep)'
+                echo '⚠️ Rebuild the arm template (from the deploy folder run az bicep build -f azuredeploy.bicep)'
                 echo '⚠️ Commit the changes'
                 exit 1
               fi


### PR DESCRIPTION
These changes improve the validation of the ARM template generated by Bicep in build pipelines. The new validation method ignores the first 10 lines of the ARM template, which can change based on the version of Bicep used. Also, the error message has been improved to provide more detail about the error.