### PR TITLE
Import method unit tests

### DIFF
--- a/src/GoogleFitOnFhir.PublishData/Startup.cs
+++ b/src/GoogleFitOnFhir.PublishData/Startup.cs
@@ -57,6 +57,7 @@ namespace GoogleFitOnFhir.PublishData
             builder.Services.AddSingleton<GoogleFitExceptionTelemetryProcessor>();
             builder.Services.AddSingleton<ITelemetryLogger, TelemetryLogger>();
             builder.Services.AddSingleton<IGoogleFitDataImporter, GoogleFitDataImporter>();
+            builder.Services.AddSingleton(typeof(Func<DateTimeOffset>), () => DateTimeOffset.UtcNow);
             builder.Services.AddSingleton(sp => sp.CreateOrderedHandlerChain<ImportRequest, Task>(typeof(GoogleFitDataImportHandler), typeof(UnknownDataImportHandler)));
         }
     }

--- a/src/GoogleFitOnFhir.PublishData/Startup.cs
+++ b/src/GoogleFitOnFhir.PublishData/Startup.cs
@@ -52,7 +52,7 @@ namespace GoogleFitOnFhir.PublishData
             builder.Services.AddSingleton<IImporterService, ImporterService>();
             builder.Services.AddSingleton<GoogleFitDataImportHandler>();
             builder.Services.AddSingleton<UnknownDataImportHandler>();
-            builder.Services.AddSingleton<GoogleFitImportService>();
+            builder.Services.AddSingleton<IGoogleFitImportService, GoogleFitImportService>();
             builder.Services.AddSingleton<GoogleFitImportOptions>();
             builder.Services.AddSingleton<GoogleFitExceptionTelemetryProcessor>();
             builder.Services.AddSingleton<ITelemetryLogger, TelemetryLogger>();

--- a/src/GoogleFitOnFhir.UnitTests/GoogleFitDataImporterTests.cs
+++ b/src/GoogleFitOnFhir.UnitTests/GoogleFitDataImporterTests.cs
@@ -1,0 +1,214 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Producer;
+using GoogleFitOnFhir.Clients.GoogleFit;
+using GoogleFitOnFhir.Clients.GoogleFit.Config;
+using GoogleFitOnFhir.Clients.GoogleFit.Models;
+using GoogleFitOnFhir.Clients.GoogleFit.Responses;
+using GoogleFitOnFhir.Common;
+using GoogleFitOnFhir.Models;
+using GoogleFitOnFhir.Repositories;
+using GoogleFitOnFhir.Services;
+using GoogleFitOnFhir.UnitTests.Mocks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Health.Logging.Telemetry;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace GoogleFitOnFhir.UnitTests
+{
+    public class GoogleFitDataImporterTests
+    {
+        private const string _userId = "me";
+        private const string _clientId = "clientId";
+        private const string _clientSecret = "clientSecret";
+        private const string _hostName = "http://localhost";
+        private const string _accessToken = "AccessToken";
+        private const string _refreshToken = "RefreshToken";
+        private const string _dataSetId = "then-now";
+        private readonly CancellationToken _cancellationToken = CancellationToken.None;
+
+        private readonly IGoogleFitImportService _googleFitImportService;
+        private readonly IGoogleFitAuthService _googleFitAuthService;
+        private readonly IUsersTableRepository _usersTableRepository;
+        private readonly IGoogleFitClient _googleFitClient;
+        private MockLogger<GoogleFitDataImporter> _dataImporterLogger;
+        private readonly IUsersKeyVaultRepository _usersKeyvaultRepository;
+        private readonly IGoogleFitDataImporter _googleFitDataImporter;
+
+        public GoogleFitDataImporterTests()
+        {
+            // GoogleFitDataImporter dependencies
+            _usersTableRepository = Substitute.For<IUsersTableRepository>();
+            _googleFitClient = Substitute.For<IGoogleFitClient>();
+            _dataImporterLogger = Substitute.For<MockLogger<GoogleFitDataImporter>>();
+            _usersKeyvaultRepository = Substitute.For<IUsersKeyVaultRepository>();
+            _googleFitAuthService = Substitute.For<IGoogleFitAuthService>();
+            _googleFitImportService = Substitute.For<IGoogleFitImportService>();
+
+            // create the service
+            _googleFitDataImporter = new GoogleFitDataImporter(
+                _usersTableRepository,
+                _googleFitClient,
+                _googleFitImportService,
+                _usersKeyvaultRepository,
+                _googleFitAuthService,
+                _dataImporterLogger);
+        }
+
+        [Fact]
+        public void GivenWhenUsersKeyVaultGetByNameThrowsException_WhenImportIsCalled_ThrowsException()
+        {
+            string exceptionMessage = "import exception";
+            _usersKeyvaultRepository.GetByName(
+                Arg.Is<string>(user => user == _userId),
+                Arg.Is<CancellationToken>(cancel => cancel == _cancellationToken)).Throws(new Exception(exceptionMessage));
+
+            Assert.ThrowsAsync<Exception>(async () => await _googleFitDataImporter.Import(_userId, _cancellationToken));
+        }
+
+        [Fact]
+        public async Task GivenWhenUsersKeyVaultGetByNameThrowsAggregateException_WhenImportIsCalled_ImportLogsAnError()
+        {
+            string exceptionMessage = "import exception";
+            var exception = new AggregateException(exceptionMessage);
+            _usersKeyvaultRepository.GetByName(
+                Arg.Is<string>(user => user == _userId),
+                Arg.Is<CancellationToken>(cancel => cancel == _cancellationToken)).Throws(exception);
+
+            await _googleFitDataImporter.Import(_userId, _cancellationToken);
+
+            _dataImporterLogger.Received(1).Log(
+                Arg.Is<LogLevel>(lvl => lvl == LogLevel.Error),
+                Arg.Is<AggregateException>(exc => exc == exception),
+                Arg.Is<string>(msg => msg == exceptionMessage));
+        }
+
+        [Fact]
+        public async Task GivenWhenRefreshTokensRequestReturnsAuthTokensResponse_WhenImportIsCalled_UpsertIsCalled()
+        {
+            SetupMockSuccessReturns();
+
+            await _googleFitDataImporter.Import(_userId, _cancellationToken);
+
+            _ = _usersKeyvaultRepository.Received(1).Upsert(
+                Arg.Is<string>(userid => userid == _userId),
+                Arg.Is<string>(refresh => refresh == _refreshToken),
+                Arg.Is<CancellationToken>(cancel => cancel == _cancellationToken));
+        }
+
+        [Fact]
+        public async Task GivenWhenRefreshTokensRequestReturnsEmptyAuthTokensResponse_WhenImportIsCalled_ImportLogsAnEmptyToken()
+        {
+            SetupMockSuccessReturns();
+
+            AuthTokensResponse emptyTokensResponse = new AuthTokensResponse() { AccessToken = _accessToken, RefreshToken = string.Empty };
+
+            // override the RefreshTokensRequest call
+            _googleFitAuthService.RefreshTokensRequest(
+                Arg.Is<string>(refresh => refresh == _refreshToken), Arg.Is<CancellationToken>(token => token == _cancellationToken)).Returns(emptyTokensResponse);
+
+            await _googleFitDataImporter.Import(_userId, _cancellationToken);
+
+            _dataImporterLogger.Received(1).Log(
+                Arg.Is<LogLevel>(lvl => lvl == LogLevel.Information),
+                Arg.Is<string>(msg => msg.StartsWith($"RefreshToken is empty for {_userId}")));
+        }
+
+        [Fact]
+        public async Task GivenWhenRefreshTokensRequestReturnsNullAuthTokensResponse_WhenImportIsCalled_ImportLogsAnEmptyToken()
+        {
+            SetupMockSuccessReturns();
+
+            AuthTokensResponse emptyTokensResponse = new AuthTokensResponse() { AccessToken = _accessToken, RefreshToken = null };
+
+            // override the RefreshTokensRequest call
+            _googleFitAuthService.RefreshTokensRequest(
+                Arg.Is<string>(refresh => refresh == _refreshToken), Arg.Is<CancellationToken>(token => token == _cancellationToken)).Returns(emptyTokensResponse);
+
+            await _googleFitDataImporter.Import(_userId, _cancellationToken);
+
+            _dataImporterLogger.Received(1).Log(
+                Arg.Is<LogLevel>(lvl => lvl == LogLevel.Information),
+                Arg.Is<string>(msg => msg.StartsWith($"RefreshToken is empty for {_userId}")));
+        }
+
+        [Fact]
+        public async Task GivenWhenGetByNameReturnsRefreshToken_WhenImportIsCalled_RefreshTokensRequestIsCalled()
+        {
+            SetupMockSuccessReturns();
+
+            await _googleFitDataImporter.Import(_userId, _cancellationToken);
+
+            _ = _googleFitAuthService.Received(1).RefreshTokensRequest(
+                Arg.Is<string>(refresh => refresh == _refreshToken),
+                Arg.Is<CancellationToken>(cancel => cancel == _cancellationToken));
+        }
+
+        [Fact]
+        public async Task GivenWhenAuthTokensResponseIsValid_WhenImportIsCalled_DataSourcesListRequestIsCalled()
+        {
+            SetupMockSuccessReturns();
+
+            await _googleFitDataImporter.Import(_userId, _cancellationToken);
+
+            _ = _googleFitClient.Received(1).DataSourcesListRequest(
+                Arg.Is<string>(access => access == _accessToken),
+                Arg.Is<CancellationToken>(cancel => cancel == _cancellationToken));
+        }
+
+        [Fact]
+        public async Task GivenWhenAuthTokensResponseIsValid_WhenImportIsCalled_GetByIdIsCalled()
+        {
+            SetupMockSuccessReturns();
+
+            await _googleFitDataImporter.Import(_userId, _cancellationToken);
+
+            _ = _usersTableRepository.Received(1).GetById(
+                Arg.Is<string>(usr => usr == _userId),
+                Arg.Is<CancellationToken>(cancel => cancel == _cancellationToken));
+        }
+
+        private void SetupMockSuccessReturns()
+        {
+            AuthTokensResponse tokensResponse = new AuthTokensResponse() { AccessToken = _accessToken, RefreshToken = _refreshToken };
+            DataSourcesListResponse dataSourcesListResponse = new DataSourcesListResponse() { DataSources = new List<DataSource>() };
+            User user = new User(_userId, Constants.GoogleFitPlatformName);
+
+            _usersKeyvaultRepository.GetByName(
+              Arg.Is<string>(userid => userid == _userId),
+              Arg.Is<CancellationToken>(token => token == _cancellationToken)).Returns(_refreshToken);
+
+            _googleFitAuthService.RefreshTokensRequest(
+               Arg.Is<string>(refresh => refresh == _refreshToken), Arg.Is<CancellationToken>(token => token == _cancellationToken)).Returns(tokensResponse);
+
+            _googleFitClient.DataSourcesListRequest(
+              Arg.Is<string>(access => access == tokensResponse.AccessToken),
+              Arg.Is<CancellationToken>(token => token == _cancellationToken)).Returns(dataSourcesListResponse);
+
+            _usersTableRepository.GetById(
+              Arg.Is<string>(userid => userid == _userId),
+              Arg.Is<CancellationToken>(token => token == _cancellationToken)).Returns(user);
+
+            _ = _googleFitImportService.ProcessDatasetRequests(
+            Arg.Is<User>(usr => usr == user),
+            Arg.Is<IEnumerable<DataSource>>(list => list == dataSourcesListResponse.DataSources),
+            Arg.Any<string>(),
+            Arg.Is<AuthTokensResponse>(tknrsp => tknrsp == tokensResponse),
+            Arg.Is<CancellationToken>(cancel => cancel == _cancellationToken));
+
+            _ = _usersTableRepository.Update(
+                Arg.Is<User>(usr => usr == user),
+                Arg.Is<CancellationToken>(token => token == _cancellationToken));
+        }
+    }
+}

--- a/src/GoogleFitOnFhir.UnitTests/GoogleFitDataImporterTests.cs
+++ b/src/GoogleFitOnFhir.UnitTests/GoogleFitDataImporterTests.cs
@@ -36,7 +36,7 @@ namespace GoogleFitOnFhir.UnitTests
         private readonly IGoogleFitAuthService _googleFitAuthService;
         private readonly IUsersTableRepository _usersTableRepository;
         private readonly IGoogleFitClient _googleFitClient;
-        private MockLogger<GoogleFitDataImporter> _dataImporterLogger;
+        private readonly MockLogger<GoogleFitDataImporter> _dataImporterLogger;
         private readonly IUsersKeyVaultRepository _usersKeyvaultRepository;
         private readonly IGoogleFitDataImporter _googleFitDataImporter;
         private readonly Func<DateTimeOffset> _utcNowFunc;

--- a/src/GoogleFitOnFhir.UnitTests/Mocks/MockLogger.cs
+++ b/src/GoogleFitOnFhir.UnitTests/Mocks/MockLogger.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace GoogleFitOnFhir.UnitTests.Mocks
+{
+    public abstract class MockLogger<T> : ILogger<T>
+    {
+        public abstract IDisposable BeginScope<TState>(TState state);
+
+        public abstract bool IsEnabled(LogLevel logLevel);
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (exception == null)
+            {
+                Log(logLevel, formatter(state, exception));
+            }
+            else
+            {
+                Log(logLevel, exception, formatter(state, exception));
+            }
+        }
+
+        public abstract void Log(LogLevel logLevel, Exception exception, string message);
+
+        public abstract void Log(LogLevel logLevel, string message);
+    }
+}

--- a/src/GoogleFitOnFhir/Clients/GoogleFit/Handlers/GoogleFitAuthorizationHandler.cs
+++ b/src/GoogleFitOnFhir/Clients/GoogleFit/Handlers/GoogleFitAuthorizationHandler.cs
@@ -55,7 +55,7 @@ namespace GoogleFitOnFhir.Clients.GoogleFit.Handlers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex.Message);
+                _logger.LogError(ex, ex.Message);
                 return null;
             }
         }
@@ -76,7 +76,7 @@ namespace GoogleFitOnFhir.Clients.GoogleFit.Handlers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex.Message);
+                _logger.LogError(ex, ex.Message);
                 return new NotFoundObjectResult(ex.Message);
             }
         }

--- a/src/GoogleFitOnFhir/Clients/GoogleFit/Handlers/GoogleFitDataImportHandler.cs
+++ b/src/GoogleFitOnFhir/Clients/GoogleFit/Handlers/GoogleFitDataImportHandler.cs
@@ -51,7 +51,7 @@ namespace GoogleFitOnFhir.Clients.GoogleFit.Handlers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex.Message);
+                _logger.LogError(ex, ex.Message);
                 _errorHandler.HandleDataImportError(request.Message, ex);
                 return null;
             }

--- a/src/GoogleFitOnFhir/Services/GoogleFitDataImporter.cs
+++ b/src/GoogleFitOnFhir/Services/GoogleFitDataImporter.cs
@@ -19,7 +19,7 @@ namespace GoogleFitOnFhir.Services
     {
         private readonly IUsersTableRepository _usersTableRepository;
         private readonly IGoogleFitClient _googleFitClient;
-        private readonly GoogleFitImportService _googleFitImportService;
+        private readonly IGoogleFitImportService _googleFitImportService;
         private readonly ILogger<GoogleFitDataImporter> _logger;
         private readonly IUsersKeyVaultRepository _usersKeyvaultRepository;
         private readonly IGoogleFitAuthService _googleFitAuthService;
@@ -27,7 +27,7 @@ namespace GoogleFitOnFhir.Services
         public GoogleFitDataImporter(
             IUsersTableRepository usersTableRepository,
             IGoogleFitClient googleFitClient,
-            GoogleFitImportService googleFitImportService,
+            IGoogleFitImportService googleFitImportService,
             IUsersKeyVaultRepository usersKeyvaultRepository,
             IGoogleFitAuthService googleFitAuthService,
             ILogger<GoogleFitDataImporter> logger)
@@ -52,7 +52,7 @@ namespace GoogleFitOnFhir.Services
             }
             catch (AggregateException ex)
             {
-                _logger.LogError(ex.Message);
+                _logger.LogError(ex, ex.Message);
                 return;
             }
 
@@ -99,7 +99,7 @@ namespace GoogleFitOnFhir.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex.Message);
+                _logger.LogError(ex, ex.Message);
             }
 
             // Update LastSync column

--- a/src/GoogleFitOnFhir/Services/GoogleFitImportService.cs
+++ b/src/GoogleFitOnFhir/Services/GoogleFitImportService.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Producer;
 using EnsureThat;
 using GoogleFitOnFhir.Clients.GoogleFit;
@@ -20,11 +19,10 @@ using GoogleFitOnFhir.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Common.Service;
 using Microsoft.Health.Logging.Telemetry;
-using Newtonsoft.Json;
 
 namespace GoogleFitOnFhir.Services
 {
-    public class GoogleFitImportService : ParallelTaskWorker<GoogleFitImportOptions>, IAsyncDisposable
+    public class GoogleFitImportService : ParallelTaskWorker<GoogleFitImportOptions>, IGoogleFitImportService, IAsyncDisposable
     {
         private readonly IGoogleFitClient _googleFitClient;
         private readonly EventHubProducerClient _eventHubProducerClient;
@@ -45,6 +43,7 @@ namespace GoogleFitOnFhir.Services
             _telemetryLogger = EnsureArg.IsNotNull(telemetryLogger, nameof(telemetryLogger));
         }
 
+        /// <inheritdoc/>
         public async Task ProcessDatasetRequests(
             User user,
             IEnumerable<DataSource> dataSources,

--- a/src/GoogleFitOnFhir/Services/IGoogleFitImportService.cs
+++ b/src/GoogleFitOnFhir/Services/IGoogleFitImportService.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using GoogleFitOnFhir.Clients.GoogleFit.Models;
+using GoogleFitOnFhir.Clients.GoogleFit.Responses;
+using GoogleFitOnFhir.Models;
+
+namespace GoogleFitOnFhir.Services
+{
+    public interface IGoogleFitImportService
+    {
+        /// <summary>
+        /// Performs Dataset requests in parallel against the list of <see cref="DataSource"/> provided by <param ref="dataSources"></param>
+        /// </summary>
+        /// <param name="user">The user ID associated with the <param ref="dataSources"></param>.</param>
+        /// <param name="dataSources">The list of <see cref="DataSource"/> for this user, that have been granted access.</param>
+        /// <param name="datasetId">An ID that corresponds to a timestamp range.  All data within this timestamp range will be returned for each <see cref="DataSource"/> specified.</param>
+        /// <param name="tokensResponse">The <see cref="AuthTokensResponse"/> which contains the access token.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel this operation, if necessary.</param>
+        /// <returns>An empty Task.</returns>
+        public Task ProcessDatasetRequests(
+            User user,
+            IEnumerable<DataSource> dataSources,
+            string datasetId,
+            AuthTokensResponse tokensResponse,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/GoogleFitOnFhir/Services/ImporterService.cs
+++ b/src/GoogleFitOnFhir/Services/ImporterService.cs
@@ -35,7 +35,7 @@ namespace GoogleFitOnFhir.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex.Message);
+                _logger.LogError(ex, ex.Message);
                 return Task.FromException(ex);
             }
         }

--- a/src/GoogleFitOnFhir/Services/RoutingService.cs
+++ b/src/GoogleFitOnFhir/Services/RoutingService.cs
@@ -37,7 +37,7 @@ namespace GoogleFitOnFhir.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex.Message);
+                _logger.LogError(ex, ex.Message);
                 return Task.FromResult<IActionResult>(new NotFoundObjectResult(ex.Message));
             }
         }


### PR DESCRIPTION
Various unit tests for `GoogleFitDataImporter` `Import` method covering:

- `LogError` scenarios
- `GetByName` exception scenarios
- `RefreshTokensRequest` return paths
- `DataSourcesListRequest` call confirmation
- `GetById` call confirmation
- `datasetId` generation
- `ProcessDatasetRequests` exception scenario
- `LastSync` value scenarios
- `IUsersTableRepository` `Update` call confirmation